### PR TITLE
Fix production env in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import { InspectProps } from 'inspx';
 const Inspect = React.lazy(() => import('inspx'));
 
 export default function Loader(props: InspectProps) {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'production') {
     return children;
   }
   return (


### PR DESCRIPTION
`NODE_ENV` should check for `production` to return only children in production build.