### PR TITLE
feat: use e.altkey instaed of e.key

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,16 +24,20 @@ export default function Inspect({
   const nodesAtPointerRef = React.useRef<HTMLElement[]>([]);
 
   React.useEffect(() => {
+    let altKeyPressed = false;
+
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Alt') {
+      if (e.altKey) {
+        altKeyPressed = true;
         if (margin) inspectMargin(nodesAtPointerRef.current);
         if (size) inspectSize(nodesAtPointerRef.current);
         if (padding) inspectPadding(nodesAtPointerRef.current);
       }
     }
 
-    function onKeyUp(e: KeyboardEvent) {
-      if (e.key === 'Alt') {
+    function onKeyUp() {
+      if (altKeyPressed) {
+        altKeyPressed = false;
         uninspect();
       }
     }


### PR DESCRIPTION
**Short description:**
use `event.altKey` to check alt key pressed for support linux (and more compatibility)

**Context:**
I add `altKeyPressed` in `useEffect` hook to check alt key was pressed in `onKeyUp` handler to check alt key was pressed. because `e.altKey` is always `false` in keyup event. so I set `altKeyPressed` to `true` in `onKeyDown` handler and reset to `false` in `onKeyUp` handler to prevent call `uninspect` by other keyboard events is not alt key.

close #2