### PR TITLE
fix: use `PropsWithChidren`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,6 @@ import './styles.css';
 // <Inspect />
 
 export interface InspectProps {
-  children: React.ReactElement | React.ReactElement[];
   margin?: boolean;
   padding?: boolean;
   size?: boolean;
@@ -20,7 +19,7 @@ export default function Inspect({
   padding = true,
   size = true,
   disabled = process.env.NODE_ENV !== 'development',
-}: InspectProps) {
+}: React.PropsWithChildren<InspectProps>) {
   const nodesAtPointerRef = React.useRef<HTMLElement[]>([]);
 
   React.useEffect(() => {


### PR DESCRIPTION
The `PropsWithChildren` type accepts `ReactNode` as the children which includes `ReactElement` amongst other types.

This way if I use it inside a component where the children are already typed with `PropsWithChildren` it is compatible and doesn't give a type-error.

Btw this is a super handy lib when implementing UIs from Figma, thank you! 😄 